### PR TITLE
Feat/be 41 text prompt checker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 transformers
 Pillow
 python-multipart
+torch

--- a/routes/mine_image.py
+++ b/routes/mine_image.py
@@ -20,3 +20,13 @@ async def get_image_content(image: UploadFile):
 
     return { 'text_description': caption }
     
+    
+@router.post('/check-for-prompt/{prompt}')
+async def check_text_prompt(image: UploadFile, prompt: str):
+    """
+    Receives an image and prompt and returns true if the prompt exist in the image
+    """
+    image_filename, image_file = image.filename, image.file
+
+
+    return { "check_result": True }

--- a/routes/mine_image.py
+++ b/routes/mine_image.py
@@ -27,6 +27,9 @@ async def check_text_prompt(image: UploadFile, prompt: str):
     Receives an image and prompt and returns true if the prompt exist in the image
     """
     image_filename, image_file = image.filename, image.file
+    # check if image contains text prompt
+    # check_result = check_prompt(image_file, prompt)
+    check_result = False
 
 
-    return { "check_result": True }
+    return { "check_result": check_result }


### PR DESCRIPTION
**BE-41**([Task link on linear](https://linear.app/team-scale/issue/BE-41/implement-endpoint-to-check-if-text-prompt-exists-in-an-image-python))

Implement an endpoint to check if a text prompt exists in an image: 
- The endpoint receives a request with an image upload and a text prompt(query parameter).
- It then returns a boolean response that determines if that text prompt exists in the picture (True or False).

Endpoint route: /check-for-prompt/

**Note:**
Response data is mocked to **true** pending when the model task is created.